### PR TITLE
Introduce Nx monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,9 @@
 2. `python ShakerService.py`
 
 ### Frontend
-The React SPA is located in `frontend-vite` and uses Vite.
+The project now uses **Nx** to manage multiple front-end apps.
 
-1. `cd frontend-vite`
-2. `npm install`
-3. `npm run dev`
+1. Run `npm install` from the repository root. This installs dependencies and the Nx CLI.
+2. Start a frontend with `npx nx run frontend:dev` or `npx nx run frontend-vite:dev`.
 
-The application will be available at `http://localhost:5173` and communicates with the Flask API running on port `5000`.
+The Vite application is available at `http://localhost:5173` and communicates with the Flask API on port `5000`.

--- a/frontend-vite/project.json
+++ b/frontend-vite/project.json
@@ -1,0 +1,31 @@
+{
+  "name": "frontend-vite",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "root": "frontend-vite",
+  "sourceRoot": "frontend-vite/src",
+  "projectType": "application",
+  "targets": {
+    "dev": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run dev",
+        "cwd": "frontend-vite"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run build",
+        "cwd": "frontend-vite"
+      },
+      "outputs": ["{workspaceRoot}/frontend-vite/dist"]
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run lint",
+        "cwd": "frontend-vite"
+      }
+    }
+  }
+}

--- a/frontend/project.json
+++ b/frontend/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "frontend",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "root": "frontend",
+  "sourceRoot": "frontend/src",
+  "projectType": "application",
+  "targets": {
+    "dev": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run dev",
+        "cwd": "frontend"
+      }
+    },
+    "build": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "npm run build",
+        "cwd": "frontend"
+      },
+      "outputs": ["{workspaceRoot}/frontend/dist"]
+    }
+  }
+}

--- a/nx.json
+++ b/nx.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "./node_modules/nx/schemas/nx-schema.json",
+  "npmScope": "shaker",
+  "tasksRunnerOptions": {
+    "default": {
+      "runner": "@nx/workspace/tasks-runners/default",
+      "options": {
+        "cacheableOperations": ["build", "test", "lint"],
+        "parallel": 2
+      }
+    }
+  },
+  "targetDefaults": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}"]
+    }
+  },
+  "workspaceLayout": {
+    "appsDir": "",
+    "libsDir": "libs"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "shaker-monorepo",
+  "private": true,
+  "workspaces": [
+    "frontend",
+    "frontend-vite"
+  ],
+  "scripts": {
+    "dev": "npm --workspaces run dev",
+    "nx": "nx"
+  },
+  "devDependencies": {
+    "nx": "latest"
+  }
+}


### PR DESCRIPTION
## Summary
- add Nx workspace config
- define Nx `project.json` files for both frontends
- document new Nx-based workflow in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm run lint -w frontend-vite --if-present` *(fails: Cannot find package '@eslint/js' imported from `frontend-vite/eslint.config.js`)*

------
https://chatgpt.com/codex/tasks/task_e_686f3c7fd8808328ae4bcdb6929f9505